### PR TITLE
fix string_view compat for OSX Linux

### DIFF
--- a/include/metaverse/mgbubble/compat/string_view.h
+++ b/include/metaverse/mgbubble/compat/string_view.h
@@ -28,7 +28,12 @@
 #else
 
 #include <experimental/string_view>
-#define string_view std::experimental::string_view 
+namespace mgbubble{
+
+using std::experimental::basic_string_view;
+using std::experimental::string_view;
+
+} // namespace mgbubble
 
 #endif
 


### PR DESCRIPTION
Missing namespace mgbubble.
Macro re-define is bad code, modified as using. 