### PR TITLE
Temp b

### DIFF
--- a/builds/msvc-140/network/network.vcxproj
+++ b/builds/msvc-140/network/network.vcxproj
@@ -122,7 +122,7 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <Lib>
-      <AdditionalLibraryDirectories>..\..\..\..\miniupnp\miniupnpc\msvc\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\miniupnp\miniupnpc\msvc\x64\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>miniupnpc.lib</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>
@@ -144,7 +144,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <Lib>
-      <AdditionalLibraryDirectories>..\..\..\..\miniupnp\miniupnpc\msvc\x64\Release;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\miniupnp\miniupnpc\msvc\x64\$(Configuration);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>miniupnpc.lib;</AdditionalDependencies>
     </Lib>
   </ItemDefinitionGroup>

--- a/include/metaverse/consensus/libethash/mmap.h
+++ b/include/metaverse/consensus/libethash/mmap.h
@@ -38,7 +38,7 @@
 #define MAP_ANON      MAP_ANONYMOUS
 #define MAP_FAILED    ((void *) -1)
 
-void* mmap(void* start, size_t length, int prot, int flags, int fd, off_t offset);
+void* mmap(void* start, size_t length, int prot, int flags, int fd, size_t offset);
 void munmap(void* addr, size_t length);
 #else // posix, yay! ^_^
 #include <sys/mman.h>

--- a/include/metaverse/consensus/libethash/mmap_win32.c
+++ b/include/metaverse/consensus/libethash/mmap_win32.c
@@ -23,7 +23,7 @@
 # define DWORD_LO(x) (x)
 #endif
 
-void* mmap(void* start, size_t length, int prot, int flags, int fd, off_t offset)
+void* mmap(void* start, size_t length, int prot, int flags, int fd, size_t offset)
 {
     if (prot & ~(PROT_READ | PROT_WRITE | PROT_EXEC))
         return MAP_FAILED;


### PR DESCRIPTION
Resolved the compiler numeric type conversion defect when creating private chain on Windows platform, resulting in 4 byte 0 value conversion error, resulting in file mapping failure.